### PR TITLE
Improve order retrieval performance

### DIFF
--- a/src/main/java/com/mdmc/posofmyheart/application/services/impl/OrderServiceImpl.java
+++ b/src/main/java/com/mdmc/posofmyheart/application/services/impl/OrderServiceImpl.java
@@ -33,7 +33,7 @@ public class OrderServiceImpl implements OrderService {
     @Override
     @Transactional(readOnly = true)
     public List<OrderResponse> findAllOrders() {
-        return orderRepository.findAll()
+        return orderRepository.findAllWithDetails()
                 .stream()
                 .map(OrderResponseMapper.INSTANCE::toResponse)
                 .toList();

--- a/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/OrderDetailEntity.java
+++ b/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/OrderDetailEntity.java
@@ -27,15 +27,15 @@ public class OrderDetailEntity {
     @Column(name = "id_order_detail")
     private Long idOrderDetail;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_order", nullable = false)
     private OrderEntity order;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_product", nullable = false)
     private ProductEntity product;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_variant", nullable = false)
     private ProductVariantEntity variant;
 

--- a/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/OrderEntity.java
+++ b/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/OrderEntity.java
@@ -40,7 +40,7 @@ public class OrderEntity {
     @Column(name = "total_amount", precision = 10, scale = 2, nullable = false)
     private BigDecimal totalAmount;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_payment_method", nullable = false)
     private PaymentMethodEntity paymentMethod;
 

--- a/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/OrderFlavorDetailEntity.java
+++ b/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/OrderFlavorDetailEntity.java
@@ -27,7 +27,7 @@ public class OrderFlavorDetailEntity {
     @JoinColumn(name = "id_order_detail", nullable = false)
     private OrderDetailEntity orderDetail;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_flavor")
     private ProductFlavorEntity flavor;
 

--- a/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/ProductEntity.java
+++ b/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/ProductEntity.java
@@ -26,7 +26,7 @@ public class ProductEntity {
     @Column(name = "id_product")
     private Long idProduct;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_category", nullable = false)
     private ProductCategoryEntity category;
 

--- a/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/ProductVariantEntity.java
+++ b/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/entities/ProductVariantEntity.java
@@ -27,7 +27,7 @@ public class ProductVariantEntity {
     @Column(name = "id_variant")
     private Long idVariant;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_product", nullable = false)
     private ProductEntity product;
 

--- a/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/repositories/OrderRepository.java
+++ b/src/main/java/com/mdmc/posofmyheart/infrastructure/persistence/repositories/OrderRepository.java
@@ -173,4 +173,21 @@ public interface OrderRepository extends JpaRepository<OrderEntity, Long> {
             @Param("endDate") LocalDateTime endDate
     );
 
+    /**
+     * Recupera todas las órdenes con sus relaciones para evitar N+1
+     */
+    @Query("""
+        SELECT DISTINCT o FROM OrderEntity o
+            LEFT JOIN FETCH o.paymentMethod
+            LEFT JOIN FETCH o.orderDetails od
+            LEFT JOIN FETCH od.extraDetails ed
+            LEFT JOIN FETCH ed.productExtra
+            LEFT JOIN FETCH od.sauceDetails sd
+            LEFT JOIN FETCH sd.productSauce
+            LEFT JOIN FETCH od.flavorDetails fd
+            LEFT JOIN FETCH fd.flavor
+        ORDER BY o.orderDate DESC
+        """)
+    List<OrderEntity> findAllWithDetails();
+
 }


### PR DESCRIPTION
## Summary
- add fetch joins in `OrderRepository` with `findAllWithDetails`
- use `findAllWithDetails` in `OrderServiceImpl`
- set `LAZY` fetch type on many-to-one associations

## Testing
- `./gradlew test --no-daemon` *(fails: unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68528db2eef88320bc9a0e98c49317e8