### PR TITLE
Improve order creation efficiency

### DIFF
--- a/src/main/java/com/mdmc/posofmyheart/domain/patterns/builder/OrderBuilder.java
+++ b/src/main/java/com/mdmc/posofmyheart/domain/patterns/builder/OrderBuilder.java
@@ -3,13 +3,15 @@ package com.mdmc.posofmyheart.domain.patterns.builder;
 import com.mdmc.posofmyheart.application.dtos.OrderItemRequest;
 import com.mdmc.posofmyheart.application.dtos.OrderRequest;
 import com.mdmc.posofmyheart.domain.patterns.facade.EntityFinder;
+import com.mdmc.posofmyheart.api.exceptions.ProductNotFoundException;
+import com.mdmc.posofmyheart.api.exceptions.VariantNotFoundException;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 
 @Component
@@ -29,9 +31,15 @@ public class OrderBuilder {
                 .build();
     }
 
-    public OrderDetailEntity buildDetail(OrderItemRequest item) {
-        ProductEntity product = entityFinder.findProduct(item.idProduct());
-        ProductVariantEntity variant = entityFinder.findVariant(item.idVariant());
+    public OrderDetailEntity buildDetail(
+            OrderItemRequest item,
+            Map<Long, ProductEntity> products,
+            Map<Long, ProductVariantEntity> variants
+    ) {
+        ProductEntity product = Optional.ofNullable(products.get(item.idProduct()))
+                .orElseThrow(() -> new ProductNotFoundException(item.idProduct()));
+        ProductVariantEntity variant = Optional.ofNullable(variants.get(item.idVariant()))
+                .orElseThrow(() -> new VariantNotFoundException(item.idVariant()));
 
         return OrderDetailEntity.builder()
                 .product(product)

--- a/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/ExtrasProcessor.java
+++ b/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/ExtrasProcessor.java
@@ -2,32 +2,32 @@ package com.mdmc.posofmyheart.domain.patterns.chain;
 
 import com.mdmc.posofmyheart.application.dtos.OrderItemRequest;
 import com.mdmc.posofmyheart.domain.models.OrderExtrasDetail;
-import com.mdmc.posofmyheart.domain.patterns.facade.EntityFinder;
+import com.mdmc.posofmyheart.domain.patterns.facade.PreloadedEntities;
+import com.mdmc.posofmyheart.api.exceptions.ProductExtraNotFoundException;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.OrderDetailEntity;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.OrderExtraDetailEntity;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductExtraEntity;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 @Component
-@RequiredArgsConstructor
 public class ExtrasProcessor extends OrderItemProcessor {
-    private final EntityFinder entityFinder;
 
     @Override
-    public void process(OrderDetailEntity detail, OrderItemRequest item) {
+    public void process(OrderDetailEntity detail, OrderItemRequest item, PreloadedEntities preloaded) {
         Optional.ofNullable(item.extras())
                 .orElseGet(Collections::emptyList)
-                .forEach(extra -> addExtraToDetail(detail, extra));
+                .forEach(extra -> addExtraToDetail(detail, extra, preloaded.extras()));
 
-        processNext(detail, item);
+        processNext(detail, item, preloaded);
     }
 
-    private void addExtraToDetail(OrderDetailEntity detail, OrderExtrasDetail extra) {
-        ProductExtraEntity productExtra = entityFinder.findProductExtra(extra.idExtra());
+    private void addExtraToDetail(OrderDetailEntity detail, OrderExtrasDetail extra, Map<Long, ProductExtraEntity> extras) {
+        ProductExtraEntity productExtra = Optional.ofNullable(extras.get(extra.idExtra()))
+                .orElseThrow(() -> new ProductExtraNotFoundException(extra.idExtra()));
 
         OrderExtraDetailEntity extraDetail = new OrderExtraDetailEntity();
         extraDetail.setRelations(detail, productExtra);

--- a/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/FlavorsProcessor.java
+++ b/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/FlavorsProcessor.java
@@ -1,36 +1,34 @@
 package com.mdmc.posofmyheart.domain.patterns.chain;
 
 import com.mdmc.posofmyheart.application.dtos.OrderItemRequest;
-import com.mdmc.posofmyheart.domain.patterns.facade.EntityFinder;
+import com.mdmc.posofmyheart.domain.patterns.facade.PreloadedEntities;
 import com.mdmc.posofmyheart.domain.patterns.validator.FlavorValidator;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.OrderDetailEntity;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.OrderFlavorDetailEntity;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductFlavorEntity;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Optional;
 
 @Component
+@RequiredArgsConstructor
 public class FlavorsProcessor extends OrderItemProcessor {
-    private final EntityFinder entityFinder;
     private final FlavorValidator flavorValidator;
 
-    public FlavorsProcessor(EntityFinder entityFinder, FlavorValidator flavorValidator) {
-        this.entityFinder = entityFinder;
-        this.flavorValidator = flavorValidator;
-    }
-
     @Override
-    public void process(OrderDetailEntity detail, OrderItemRequest item) {
+    public void process(OrderDetailEntity detail, OrderItemRequest item, PreloadedEntities preloaded) {
         Optional.ofNullable(item.flavor())
-                .ifPresent(flavor -> addFlavorToDetail(detail, flavor));
+                .ifPresent(flavor -> addFlavorToDetail(detail, flavor, preloaded.flavors()));
 
-        processNext(detail, item);
+        processNext(detail, item, preloaded);
     }
 
-    private void addFlavorToDetail(OrderDetailEntity detail, Long idFlavor) {
-        ProductFlavorEntity flavorEntity = entityFinder.findFlavor(idFlavor);
+    private void addFlavorToDetail(OrderDetailEntity detail, Long idFlavor, Map<Long, ProductFlavorEntity> flavors) {
+        ProductFlavorEntity flavorEntity = Optional.ofNullable(flavors.get(idFlavor))
+                .orElseThrow(() -> new com.mdmc.posofmyheart.api.exceptions.FlavorNotFoundException(idFlavor));
         flavorValidator.validateFlavorForProduct(flavorEntity, detail.getProduct());
 
         OrderFlavorDetailEntity flavorDetail = new OrderFlavorDetailEntity(detail, flavorEntity);

--- a/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/OrderItemProcessor.java
+++ b/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/OrderItemProcessor.java
@@ -2,6 +2,7 @@ package com.mdmc.posofmyheart.domain.patterns.chain;
 
 import com.mdmc.posofmyheart.application.dtos.OrderItemRequest;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.OrderDetailEntity;
+import com.mdmc.posofmyheart.domain.patterns.facade.PreloadedEntities;
 
 public abstract class OrderItemProcessor {
     protected OrderItemProcessor nextProcessor;
@@ -10,11 +11,11 @@ public abstract class OrderItemProcessor {
         this.nextProcessor = next;
     }
 
-    public abstract void process(OrderDetailEntity detail, OrderItemRequest item);
+    public abstract void process(OrderDetailEntity detail, OrderItemRequest item, PreloadedEntities preloaded);
 
-    protected void processNext(OrderDetailEntity detail, OrderItemRequest item) {
+    protected void processNext(OrderDetailEntity detail, OrderItemRequest item, PreloadedEntities preloaded) {
         if (nextProcessor != null) {
-            nextProcessor.process(detail, item);
+            nextProcessor.process(detail, item, preloaded);
         }
     }
 }

--- a/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/OrderItemProcessorChain.java
+++ b/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/OrderItemProcessorChain.java
@@ -1,6 +1,7 @@
 package com.mdmc.posofmyheart.domain.patterns.chain;
 
 import com.mdmc.posofmyheart.application.dtos.OrderItemRequest;
+import com.mdmc.posofmyheart.domain.patterns.facade.PreloadedEntities;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.OrderDetailEntity;
 import org.springframework.stereotype.Component;
 
@@ -12,7 +13,7 @@ public class OrderItemProcessorChain {
         this.firstProcessor = firstProcessor;
     }
 
-    public void process(OrderDetailEntity detail, OrderItemRequest item) {
-        firstProcessor.process(detail, item);
+    public void process(OrderDetailEntity detail, OrderItemRequest item, PreloadedEntities preloaded) {
+        firstProcessor.process(detail, item, preloaded);
     }
 }

--- a/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/SaucesProcessor.java
+++ b/src/main/java/com/mdmc/posofmyheart/domain/patterns/chain/SaucesProcessor.java
@@ -1,24 +1,21 @@
 package com.mdmc.posofmyheart.domain.patterns.chain;
 
 import com.mdmc.posofmyheart.application.dtos.OrderItemRequest;
-import com.mdmc.posofmyheart.domain.patterns.facade.EntityFinder;
+import com.mdmc.posofmyheart.domain.patterns.facade.PreloadedEntities;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.OrderDetailEntity;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductSauceEntity;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 
 @Component
-@RequiredArgsConstructor
 public class SaucesProcessor extends OrderItemProcessor {
-    private final EntityFinder entityFinder;
+    
 
     @Override
-    public void process(OrderDetailEntity detail, OrderItemRequest item) {
+    public void process(OrderDetailEntity detail, OrderItemRequest item, PreloadedEntities preloaded) {
         if (detail.getSauceDetails() == null) {
             detail.setSauceDetails(new HashSet<>());
         }
@@ -26,11 +23,12 @@ public class SaucesProcessor extends OrderItemProcessor {
         Optional.ofNullable(item.sauces())
                 .orElseGet(Collections::emptyList)
                 .forEach(sauce -> {
-                    ProductSauceEntity productSauceEntity = entityFinder.findSauce(sauce.idSauce());
+                    ProductSauceEntity productSauceEntity = Optional.ofNullable(preloaded.sauces().get(sauce.idSauce()))
+                            .orElseThrow(() -> new com.mdmc.posofmyheart.api.exceptions.ProductSauceNotFoundException(sauce.idSauce()));
                     detail.addSauce(productSauceEntity);
                 });
 
-        processNext(detail, item);
+        processNext(detail, item, preloaded);
     }
 
 }

--- a/src/main/java/com/mdmc/posofmyheart/domain/patterns/facade/EntityFinder.java
+++ b/src/main/java/com/mdmc/posofmyheart/domain/patterns/facade/EntityFinder.java
@@ -6,6 +6,11 @@ import com.mdmc.posofmyheart.infrastructure.persistence.repositories.*;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Component
 @AllArgsConstructor
 public class EntityFinder {
@@ -44,5 +49,70 @@ public class EntityFinder {
     public ProductFlavorEntity findFlavor(Long id) {
         return flavorRepository.findById(id)
                 .orElseThrow(() -> new FlavorNotFoundException(id));
+    }
+
+    public Map<Long, ProductEntity> findProducts(Collection<Long> ids) {
+        Map<Long, ProductEntity> map = productRepository.findAllById(ids)
+                .stream()
+                .collect(Collectors.toMap(ProductEntity::getIdProduct, Function.identity()));
+        ids.stream()
+                .filter(id -> !map.containsKey(id))
+                .findFirst()
+                .ifPresent(id -> {
+                    throw new ProductNotFoundException(id);
+                });
+        return map;
+    }
+
+    public Map<Long, ProductVariantEntity> findVariants(Collection<Long> ids) {
+        Map<Long, ProductVariantEntity> map = variantRepository.findAllById(ids)
+                .stream()
+                .collect(Collectors.toMap(ProductVariantEntity::getIdVariant, Function.identity()));
+        ids.stream()
+                .filter(id -> !map.containsKey(id))
+                .findFirst()
+                .ifPresent(id -> {
+                    throw new VariantNotFoundException(id);
+                });
+        return map;
+    }
+
+    public Map<Long, ProductExtraEntity> findProductExtras(Collection<Long> ids) {
+        Map<Long, ProductExtraEntity> map = productExtraRepository.findAllById(ids)
+                .stream()
+                .collect(Collectors.toMap(ProductExtraEntity::getIdExtra, Function.identity()));
+        ids.stream()
+                .filter(id -> !map.containsKey(id))
+                .findFirst()
+                .ifPresent(id -> {
+                    throw new ProductExtraNotFoundException(id);
+                });
+        return map;
+    }
+
+    public Map<Long, ProductSauceEntity> findSauces(Collection<Long> ids) {
+        Map<Long, ProductSauceEntity> map = productSauceRepository.findAllById(ids)
+                .stream()
+                .collect(Collectors.toMap(ProductSauceEntity::getIdSauce, Function.identity()));
+        ids.stream()
+                .filter(id -> !map.containsKey(id))
+                .findFirst()
+                .ifPresent(id -> {
+                    throw new ProductSauceNotFoundException(id);
+                });
+        return map;
+    }
+
+    public Map<Long, ProductFlavorEntity> findFlavors(Collection<Long> ids) {
+        Map<Long, ProductFlavorEntity> map = flavorRepository.findAllById(ids)
+                .stream()
+                .collect(Collectors.toMap(ProductFlavorEntity::getIdFlavor, Function.identity()));
+        ids.stream()
+                .filter(id -> !map.containsKey(id))
+                .findFirst()
+                .ifPresent(id -> {
+                    throw new FlavorNotFoundException(id);
+                });
+        return map;
     }
 }

--- a/src/main/java/com/mdmc/posofmyheart/domain/patterns/facade/PreloadedEntities.java
+++ b/src/main/java/com/mdmc/posofmyheart/domain/patterns/facade/PreloadedEntities.java
@@ -1,0 +1,13 @@
+package com.mdmc.posofmyheart.domain.patterns.facade;
+
+import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductExtraEntity;
+import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductFlavorEntity;
+import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductSauceEntity;
+
+import java.util.Map;
+
+public record PreloadedEntities(
+        Map<Long, ProductExtraEntity> extras,
+        Map<Long, ProductSauceEntity> sauces,
+        Map<Long, ProductFlavorEntity> flavors
+) {}

--- a/src/main/java/com/mdmc/posofmyheart/domain/patterns/factory/OrderFactory.java
+++ b/src/main/java/com/mdmc/posofmyheart/domain/patterns/factory/OrderFactory.java
@@ -1,25 +1,68 @@
 package com.mdmc.posofmyheart.domain.patterns.factory;
 
 import com.mdmc.posofmyheart.application.dtos.OrderRequest;
+import com.mdmc.posofmyheart.application.dtos.OrderItemRequest;
 import com.mdmc.posofmyheart.domain.patterns.builder.OrderBuilder;
 import com.mdmc.posofmyheart.domain.patterns.chain.OrderItemProcessorChain;
+import com.mdmc.posofmyheart.domain.patterns.facade.EntityFinder;
+import com.mdmc.posofmyheart.domain.patterns.facade.PreloadedEntities;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.OrderDetailEntity;
 import com.mdmc.posofmyheart.infrastructure.persistence.entities.OrderEntity;
+import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductEntity;
+import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductVariantEntity;
+import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductExtraEntity;
+import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductSauceEntity;
+import com.mdmc.posofmyheart.infrastructure.persistence.entities.ProductFlavorEntity;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 @AllArgsConstructor
 public class OrderFactory {
     private final OrderBuilder orderBuilder;
     private final OrderItemProcessorChain processorChain;
+    private final EntityFinder entityFinder;
 
     public OrderEntity createOrder(OrderRequest request) {
         OrderEntity order = orderBuilder.buildFromRequest(request);
 
+        Set<Long> productIds = request.items().stream()
+                .map(OrderItemRequest::idProduct)
+                .collect(Collectors.toSet());
+        Set<Long> variantIds = request.items().stream()
+                .map(OrderItemRequest::idVariant)
+                .collect(Collectors.toSet());
+        Set<Long> extraIds = request.items().stream()
+                .flatMap(i -> Optional.ofNullable(i.extras()).orElse(Collections.emptyList()).stream())
+                .map(e -> e.idExtra())
+                .collect(Collectors.toSet());
+        Set<Long> sauceIds = request.items().stream()
+                .flatMap(i -> Optional.ofNullable(i.sauces()).orElse(Collections.emptyList()).stream())
+                .map(s -> s.idSauce())
+                .collect(Collectors.toSet());
+        Set<Long> flavorIds = request.items().stream()
+                .map(OrderItemRequest::flavor)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        Map<Long, ProductEntity> products = entityFinder.findProducts(productIds);
+        Map<Long, ProductVariantEntity> variants = entityFinder.findVariants(variantIds);
+        Map<Long, ProductExtraEntity> extras = entityFinder.findProductExtras(extraIds);
+        Map<Long, ProductSauceEntity> sauces = entityFinder.findSauces(sauceIds);
+        Map<Long, ProductFlavorEntity> flavors = entityFinder.findFlavors(flavorIds);
+
+        PreloadedEntities preloaded = new PreloadedEntities(extras, sauces, flavors);
+
         request.items().forEach(item -> {
-            OrderDetailEntity detail = orderBuilder.buildDetail(item);
-            processorChain.process(detail, item);
+            OrderDetailEntity detail = orderBuilder.buildDetail(item, products, variants);
+            processorChain.process(detail, item, preloaded);
             detail.setOrder(order);
             order.addOrderDetail(detail);
         });


### PR DESCRIPTION
## Summary
- add `PreloadedEntities` record to bundle extras, sauces and flavors
- extend `EntityFinder` with bulk lookup helpers
- preload entities in `OrderFactory` and use them while building order details
- update `OrderBuilder` and processors to consume preloaded data

## Testing
- `sh gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68537e2cb1388320ab329a767a91e163